### PR TITLE
fix: queryType should be `traceql`

### DIFF
--- a/docker/grafana/provisioning/dashboards/logs_traces_metrics.json
+++ b/docker/grafana/provisioning/dashboards/logs_traces_metrics.json
@@ -87,7 +87,7 @@
                         "uid": "tempo"
                     },
                     "query": "$traceID",
-                    "queryType": "traceId",
+                    "queryType": "traceql",
                     "refId": "A"
                 }
             ],


### PR DESCRIPTION
To ensure proper functionality of the Trace View, the `queryType` field should be `traceql`.